### PR TITLE
Fix check run size

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod constants;
 mod event;
 #[cfg(test)]
 mod fixtures;
+mod nightly_backports;
 mod octocrab_utils;
 mod repo_cache;
 mod server;

--- a/src/nightly_backports.rs
+++ b/src/nightly_backports.rs
@@ -1,0 +1,27 @@
+/// Finds the closest `x` not exceeding `index` where `is_char_boundary(x)` is `true`.
+///
+/// This method can help you truncate a string so that it's still valid UTF-8, but doesn't
+/// exceed a given number of bytes.
+///
+/// See <https://doc.rust-lang.org/std/primitive.str.html#method.floor_char_boundary>
+#[inline]
+pub(crate) fn floor_char_boundary(s: &str, index: usize) -> usize {
+    if index >= s.len() {
+        s.len()
+    } else {
+        let lower_bound = index.saturating_sub(3);
+        let new_index = s.as_bytes()[lower_bound..=index]
+            .iter()
+            .rposition(|b| is_utf8_char_boundary(*b));
+
+        // SAFETY: we know that the character boundary will be within four bytes
+        unsafe { lower_bound + new_index.unwrap_unchecked() }
+    }
+}
+
+#[allow(clippy::cast_possible_wrap)]
+#[inline]
+pub(crate) fn is_utf8_char_boundary(b: u8) -> bool {
+    // This is bit magic equivalent to: b < 128 || b >= 192
+    (b as i8) >= -0x40
+}

--- a/src/server/runner.rs
+++ b/src/server/runner.rs
@@ -18,7 +18,7 @@ pub(crate) async fn runner(mut receiver: Receiver<Event>) {
             .instrument(tracing::info_span!("handle_event"))
             .await
         {
-            tracing::error!("{error}");
+            tracing::error!("Handle event error: {error:?}");
         }
     }
 }

--- a/src/server/runner/checks.rs
+++ b/src/server/runner/checks.rs
@@ -7,6 +7,8 @@ use octocrab::{
     params::checks::{CheckRunConclusion, CheckRunOutput, CheckRunStatus},
 };
 
+use crate::server::octocrab_utils::clamp_lines;
+
 pub(super) async fn with_check<Fut>(
     checks: ChecksHandler<'_>,
     check_id: CheckRunId,
@@ -30,7 +32,7 @@ where
     let (conclusion, res) = match func().await {
         Ok(text) => {
             output.summary = "Benchmark run successful".to_owned();
-            output.text = Some(text.clone());
+            output.text = Some(clamp_lines(&text, u16::MAX.into()).to_owned());
             (CheckRunConclusion::Success, Ok(text))
         }
         Err(e) => {


### PR DESCRIPTION
TODO: fix failing check run update

> Only 65535 characters are allowed; 421448 were supplied.