### PR TITLE
Specify envs for comparison as well

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -30,10 +30,13 @@ async fn main() -> Result<()> {
             server::serve(args).await?;
         }
         cli::Commands::Run(args) => {
-            let wd = benchmark::sync_repo_and_run(&args).await?;
+            let (wd, env_specs) = benchmark::sync_repo_and_run(&args).await?;
             // if exactly two are specified, show a comparison
             if let [before, after] = args.run_on.as_slice() {
-                benchmark::AsvCompare::new(&wd, before, after).run().await?;
+                benchmark::AsvCompare::new(&wd, before, after)
+                    .in_envs(env_specs)
+                    .run()
+                    .await?;
             }
         }
     }


### PR DESCRIPTION
With #35 in place, we can reuse the information to restrict the comparison tables as well, and avoid stuff like this:

![grafik](https://github.com/scverse/benchmark/assets/291575/073d160a-ae22-4b9c-b772-07daf96884e4)
