### PR TITLE
(feat): add `--launch-method=spawn` for GPU

### DIFF
--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -149,7 +149,9 @@ async fn run_benchmark(repo: git2::Repository, on: &[String]) -> Result<(PathBuf
     tracing::info!("Running asv in {}", wd.display());
     let mut command = asv_command(&wd);
     let env_specs = resolve_env(&wd).await?;
-    command.arg("run").args(env_specs.args());
+    command
+        .args(["run", "--launch-method=spawn"])
+        .args(env_specs.args());
     // Adding .arg("--skip-existing-commits") would skip even if benchmarks changed
     let mut child = if on.is_empty() {
         command.spawn().context("failed to spawn `asv run`")?


### PR DESCRIPTION
Fix for `cupy_backends.cuda.api.runtime.CUDARuntimeError: cudaErrorInitializationError: initialization error` because `--launch-method` uses forking by default - see e.g., https://stackoverflow.com/questions/71511148/python-multiprocessing-error-along-using-cupy

Using `-vvv` didn't print out this part of the command from what I can see unfortunately.